### PR TITLE
Move grabbers configuration from defs.h to configure-grabbers.prf

### DIFF
--- a/Software/common/defs.h
+++ b/Software/common/defs.h
@@ -28,22 +28,5 @@
 
 #include <qglobal.h>
 
-//#define QT_GRAB_SUPPORT
-#ifdef Q_OS_WIN
-//#   define ALIEN_FX_SUPPORTED
-#   define WINAPI_GRAB_SUPPORT
-//#   define WINAPI_EACH_GRAB_SUPPORT
-//#   define D3D9_GRAB_SUPPORT
-#   define D3D10_GRAB_SUPPORT
-#elif defined(Q_OS_UNIX)
-#   define X11_GRAB_SUPPORT
-#endif
-
-#if defined(Q_OS_DARWIN) || defined(Q_OS_DARWIN64) || defined(Q_OS_MAC) || defined(Q_OS_MACX) || defined(Q_OS_MAC64)
-#   define MAC_OS
-#   define MAC_OS_CG_GRAB_SUPPORT
-#   undef X11_GRAB_SUPPORT
-#endif
-
 #define DEBUG_OUT_RGB( RGB_VALUE ) \
     qDebug() << #RGB_VALUE << "=" << qRed(RGB_VALUE) << qGreen(RGB_VALUE) << qBlue(RGB_VALUE)

--- a/Software/grab/configure-grabbers.prf
+++ b/Software/grab/configure-grabbers.prf
@@ -1,0 +1,21 @@
+# Grabber types detection
+# Linux/UNIX platform
+unix:!macx {
+    SUPPORTED_GRABBERS += X11_GRAB_SUPPORT
+}
+
+# Mac platform
+macx {
+    SUPPORTED_GRABBERS += MAC_OS_CG_GRAB_SUPPORT
+}
+
+# Windows platform
+win32 {
+    # SUPPORTED_GRABBERS += WINAPI_EACH_GRAB_SUPPORT
+    # SUPPORTED_GRABBERS += D3D9_GRAB_SUPPORT
+    SUPPORTED_GRABBERS += WINAPI_GRAB_SUPPORT
+    SUPPORTED_GRABBERS += D3D10_GRAB_SUPPORT
+}
+
+# Disabled for now
+# SUPPORTED_GRABBERS += QT_GRAB_SUPPORT

--- a/Software/grab/grab.pro
+++ b/Software/grab/grab.pro
@@ -13,26 +13,78 @@ CONFIG += staticlib
 
 include(../build-config.prf)
 
+# Grabber types configuration
+include(configure-grabbers.prf)
+
 LIBS += -lprismatik-math
 
 INCLUDEPATH += ./include ../src ../math/include
 
+DEFINES += $${SUPPORTED_GRABBERS}
+# Linux/UNIX platform
+unix:!macx {
+    contains(DEFINES, X11_GRAB_SUPPORT) {
+        GRABBERS_HEADERS += include/X11Grabber.hpp
+        GRABBERS_SOURCES += X11Grabber.cpp
+    }
+}
+
+# Mac platform
+macx {
+    contains(DEFINES, MAC_OS_CG_GRAB_SUPPORT) {
+        GRABBERS_HEADERS += include/MacOSGrabber.hpp
+        GRABBERS_SOURCES += MacOSGrabber.cpp
+    }
+}
+
+# Windows platform
+win32 {
+    contains(DEFINES, WINAPI_GRAB_SUPPORT) {
+        GRABBERS_HEADERS += include/WinAPIGrabber.hpp
+        GRABBERS_SOURCES += WinAPIGrabber.cpp
+    }
+
+    contains(DEFINES, WINAPI_EACH_GRAB_SUPPORT) {
+        GRABBERS_HEADERS += include/WinAPIGrabberEachWidget.hpp
+        GRABBERS_SOURCES += WinAPIGrabberEachWidget.cpp
+    }
+
+    contains(DEFINES, D3D9_GRAB_SUPPORT) {
+        GRABBERS_HEADERS += include/D3D9Grabber.hpp
+        GRABBERS_SOURCES += D3D9Grabber.cpp
+    }
+
+    contains(DEFINES, D3D10_GRAB_SUPPORT) {
+        GRABBERS_HEADERS += include/D3D10Grabber.hpp
+        GRABBERS_SOURCES += D3D10Grabber.cpp
+    }
+}
+
+# Common Qt grabbers
+contains(DEFINES, QT_GRAB_SUPPORT) {
+    GRABBERS_HEADERS += \
+        include/QtGrabberEachWidget.hpp \
+        include/QtGrabber.hpp
+
+    GRABBERS_SOURCES += \
+        QtGrabberEachWidget.cpp \
+        QtGrabber.cpp
+}
+
 HEADERS += \
     include/calculations.hpp \
     include/TimeredGrabber.hpp \
-    include/QtGrabberEachWidget.hpp \
-    include/QtGrabber.hpp \
     include/GrabberBase.hpp \
     include/ColorProvider.hpp \
-    include/GrabberContext.hpp
+    include/GrabberContext.hpp \
+    $${GRABBERS_HEADERS}
 
 SOURCES += \
     calculations.cpp \
     TimeredGrabber.cpp \
-    QtGrabberEachWidget.cpp \
-    QtGrabber.cpp \
     GrabberBase.cpp \
-    include/ColorProvider.cpp
+    include/ColorProvider.cpp \
+    $${GRABBERS_SOURCES}
 
 win32 {
     # This will suppress gcc warnings in DX headers.
@@ -49,17 +101,9 @@ win32 {
 
     HEADERS += \
             ../common/msvcstub.h \
-            include/D3D9Grabber.hpp \
-            include/D3D10Grabber.hpp \
-            include/WinAPIGrabberEachWidget.hpp \
-            include/WinAPIGrabber.hpp \
             include/WinUtils.hpp \
             include/WinDXUtils.hpp
     SOURCES += \
-            D3D9Grabber.cpp \
-            D3D10Grabber.cpp \
-            WinAPIGrabberEachWidget.cpp \
-            WinAPIGrabber.cpp \
             WinUtils.cpp \
             WinDXUtils.cpp
 }
@@ -72,20 +116,8 @@ macx {
     #LIBS += \
     #        -framework CoreGraphics
     #        -framework CoreFoundation
-
-    HEADERS += \
-            include/MacOSGrabber.hpp
-
-    SOURCES += \
-            MacOSGrabber.cpp
-
     #QMAKE_MAC_SDK = macosx10.8
 }
 
-unix:!macx {
-    HEADERS += \
-            include/X11Grabber.hpp
-
-    SOURCES += \
-            X11Grabber.cpp
-}
+OTHER_FILES += \
+    configure-grabbers.prf

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -52,6 +52,10 @@ RC_FILE      = ../res/Lightpack.rc
 
 include(../build-config.prf)
 
+# Grabber types configuration
+include(../grab/configure-grabbers.prf)
+DEFINES += $${SUPPORTED_GRABBERS}
+
 LIBS    += -L../lib -lgrab -lprismatik-math
 
 unix:!macx{


### PR DESCRIPTION
On clean rebuild in QtCreator I have some annoying messages like this:

...
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libgrab.a(QtGrabberEachWidget.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libgrab.a(QtGrabber.o) has no symbols
...

because these *.cpp files contain preprocessor guards and the preprocessed *.cpp doesn't contain any code.
So I decided to move grabbers configuration from common/defs.h header.
It is possible, because the set of available grabbers depends only on current platform.
I think that project files should manage which sources will take part in the build process, but not the preprocessor.
