### PR TITLE
Implement LightpackCommandLineParser class.

### DIFF
--- a/Software/src/LightpackCommandLineParser.cpp
+++ b/Software/src/LightpackCommandLineParser.cpp
@@ -1,0 +1,119 @@
+#include "LightpackCommandLineParser.hpp"
+
+LightpackCommandLineParser::LightpackCommandLineParser()
+    : m_noGUIOption("nogui", "Run application without a GUI.")
+    , m_wizardOption("wizard", "Run settings wizard dialog.")
+    , m_backlightOffOption("off", "Turn backlight off.")
+    , m_backlightOnOption("on", "Turn backlight off.")
+    , m_debugLevelOption("debug", "Set application debug level to [high|mid|low|zero].", "debug")
+    , m_debugLevelHighOption("debug-high", "Set application debug level to high.")
+    , m_debugLevelMidOption("debug-mid", "Set application debug level to mid.")
+    , m_debugLevelLowOption("debug-low", "Set application debug level to low.")
+    , m_debugLevelZeroOption("debug-zero", "Set application debug level to zero.")
+    , m_versionOption(m_parser.addVersionOption())
+    , m_helpOption(m_parser.addHelpOption())
+{
+    m_parser.addOption(m_noGUIOption);
+    m_parser.addOption(m_wizardOption);
+    m_parser.addOption(m_backlightOffOption);
+    m_parser.addOption(m_backlightOnOption);
+    m_parser.addOption(m_debugLevelOption);
+    m_parser.addOption(m_debugLevelHighOption);
+    m_parser.addOption(m_debugLevelMidOption);
+    m_parser.addOption(m_debugLevelLowOption);
+    m_parser.addOption(m_debugLevelZeroOption);
+}
+
+bool LightpackCommandLineParser::isSetNoGUI() const
+{
+    return m_parser.isSet(m_noGUIOption);
+}
+
+bool LightpackCommandLineParser::isSetWizard() const
+{
+    return m_parser.isSet(m_wizardOption);
+}
+
+bool LightpackCommandLineParser::isSetBacklightOff() const
+{
+    return m_parser.isSet(m_backlightOffOption);
+}
+
+bool LightpackCommandLineParser::isSetBacklightOn() const
+{
+    return m_parser.isSet(m_backlightOnOption);
+}
+
+bool LightpackCommandLineParser::isSetVersion() const
+{
+    return m_parser.isSet(m_versionOption);
+}
+
+bool LightpackCommandLineParser::isSetHelp() const
+{
+    return m_parser.isSet(m_helpOption);
+}
+
+bool LightpackCommandLineParser::isSetDebuglevel() const
+{
+    return m_parser.isSet(m_debugLevelOption) ||
+        m_parser.isSet(m_debugLevelHighOption) ||
+        m_parser.isSet(m_debugLevelMidOption) ||
+        m_parser.isSet(m_debugLevelLowOption) ||
+        m_parser.isSet(m_debugLevelZeroOption);
+}
+
+Debug::DebugLevels LightpackCommandLineParser::debugLevel() const
+{
+    Q_ASSERT(isSetDebuglevel());
+    return m_debugLevel;
+}
+
+// static
+Debug::DebugLevels LightpackCommandLineParser::parseDebugLevel(const QString& levelValue)
+{
+    if (levelValue == "high")
+        return Debug::HighLevel;
+    else if (levelValue == "mid")
+        return Debug::MidLevel;
+    else if (levelValue == "low")
+        return Debug::LowLevel;
+    else if (levelValue == "zero")
+        return Debug::ZeroLevel;
+
+    Q_ASSERT(false);
+    return Debug::ZeroLevel;
+}
+
+bool LightpackCommandLineParser::parse(QString *errorMessage, const QStringList &arguments)
+{
+    if (!m_parser.parse(arguments))
+    {
+        if (errorMessage)
+            *errorMessage = m_parser.errorText();
+        return false;
+    }
+
+    if (m_parser.isSet(m_debugLevelOption))
+    {
+        const QString levelValue(m_parser.value(m_debugLevelOption));
+        m_debugLevel = parseDebugLevel(levelValue);
+    }
+    else if (m_parser.isSet(m_debugLevelHighOption))
+        m_debugLevel = Debug::HighLevel;
+    else if (m_parser.isSet(m_debugLevelMidOption))
+        m_debugLevel = Debug::MidLevel;
+    else if (m_parser.isSet(m_debugLevelLowOption))
+        m_debugLevel = Debug::LowLevel;
+    else if (m_parser.isSet(m_debugLevelZeroOption))
+        m_debugLevel = Debug::ZeroLevel;
+
+    if (isSetBacklightOff() && isSetBacklightOn())
+    {
+        if (errorMessage)
+            *errorMessage = "Bad options specified!";
+        return false;
+    }
+
+    return true;
+}

--- a/Software/src/LightpackCommandLineParser.hpp
+++ b/Software/src/LightpackCommandLineParser.hpp
@@ -1,0 +1,75 @@
+/*
+ * LightpackCommandLineParser.hpp
+ *
+ *  Created on: 08.08.2014
+ *     Project: Lightpack
+ *
+ *  Lightpack is very simple implementation of the backlight for a laptop
+ *
+ *  Copyright (c) 2014 Woodenshark LLC
+ *
+ *  Lightpack is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Lightpack is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef LIGHTPACKCOMMANDLINEPARSER_H
+#define LIGHTPACKCOMMANDLINEPARSER_H
+
+#include "debug.h"
+#include <QCoreApplication>
+#include <QCommandLineParser>
+
+class LightpackCommandLineParser {
+public:
+    LightpackCommandLineParser();
+
+    bool isSetVersion() const;
+    bool isSetHelp() const;
+    bool isSetNoGUI() const;
+    bool isSetWizard() const;
+    bool isSetBacklightOff() const;
+    bool isSetBacklightOn() const;
+    bool isSetDebuglevel() const;
+    // Valid only if isSetDebuglevel() is true.
+    Debug::DebugLevels debugLevel() const;
+
+    bool parse(QString *errorMessage, const QStringList& arguments = QCoreApplication::arguments());
+
+private:
+    static Debug::DebugLevels parseDebugLevel(const QString& levelValue);
+
+    QCommandLineParser m_parser;
+    // Options
+    // --nogui
+    const QCommandLineOption m_noGUIOption;
+    // --wizard
+    const QCommandLineOption m_wizardOption;
+    // --off
+    const QCommandLineOption m_backlightOffOption;
+    // --on
+    const QCommandLineOption m_backlightOnOption;
+    // --debug=[high | mid | low | zero]
+    const QCommandLineOption m_debugLevelOption;
+    const QCommandLineOption m_debugLevelHighOption;
+    const QCommandLineOption m_debugLevelMidOption;
+    const QCommandLineOption m_debugLevelLowOption;
+    const QCommandLineOption m_debugLevelZeroOption;
+    const QCommandLineOption m_versionOption;
+    const QCommandLineOption m_helpOption;
+
+    // Values from command line.
+    Debug::DebugLevels m_debugLevel;
+};
+
+#endif // LIGHTPACKCOMMANDLINEPARSER_H

--- a/Software/src/src.pro
+++ b/Software/src/src.pro
@@ -213,7 +213,8 @@ SOURCES += \
     wizard/CassiopeiaDistributor.cpp \
     wizard/PegasusDistributor.cpp \
     systrayicon/SysTrayIcon.cpp \
-    UpdatesProcessor.cpp
+    UpdatesProcessor.cpp \
+    LightpackCommandLineParser.cpp
 
 HEADERS += \
     LightpackApplication.hpp \
@@ -267,7 +268,8 @@ HEADERS += \
     wizard/PegasusDistributor.hpp \
     systrayicon/SysTrayIcon.hpp \
     systrayicon/SysTrayIcon_p.hpp \
-    UpdatesProcessor.hpp
+    UpdatesProcessor.hpp \
+    LightpackCommandLineParser.hpp
 
 !contains(DEFINES,UNITY_DESKTOP) {
     HEADERS += systrayicon/SysTrayIcon_qt_p.hpp

--- a/Software/tests/LightpackCommandLineParserTest.cpp
+++ b/Software/tests/LightpackCommandLineParserTest.cpp
@@ -1,0 +1,111 @@
+#include "LightpackCommandLineParserTest.hpp"
+#include "LightpackCommandLineParser.hpp"
+#include <QtTest/QtTest>
+
+LightpackCommandLineParserTest::LightpackCommandLineParserTest(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void LightpackCommandLineParserTest::initTestCase() {}
+void LightpackCommandLineParserTest::init() {}
+void LightpackCommandLineParserTest::cleanup() {}
+
+void LightpackCommandLineParserTest::testCase_parseVersion()
+{
+    LightpackCommandLineParser parser;
+    QString error;
+    const QStringList arguments = QStringList() << "app.binary" << "--version";
+
+    QVERIFY(parser.parse(&error, arguments));
+    QVERIFY(parser.isSetVersion());
+
+    const QStringList arguments2 = QStringList() << "app.binary" << "-v";
+    QVERIFY(parser.parse(&error, arguments2));
+    QVERIFY(parser.isSetVersion());
+}
+
+void LightpackCommandLineParserTest::testCase_parseHelp()
+{
+    LightpackCommandLineParser parser;
+    QString error;
+    const QStringList arguments = QStringList() << "app.binary" << "--help";
+
+    QVERIFY(parser.parse(&error, arguments));
+    QVERIFY(parser.isSetHelp());
+
+    const QStringList arguments2 = QStringList() << "app.binary" << "-h";
+    QVERIFY(parser.parse(&error, arguments2));
+    QVERIFY(parser.isSetHelp());
+}
+
+void LightpackCommandLineParserTest::testCase_parseWizard()
+{
+    LightpackCommandLineParser parser;
+    QString error;
+    const QStringList arguments = QStringList() << "app.binary" << "--wizard";
+
+    QVERIFY(parser.parse(&error, arguments));
+    QVERIFY(parser.isSetWizard());
+}
+
+void LightpackCommandLineParserTest::testCase_parseBacklightOff()
+{
+    LightpackCommandLineParser parser;
+    QString error;
+    const QStringList arguments = QStringList() << "app.binary" << "--off";
+
+    QVERIFY(parser.parse(&error, arguments));
+    QVERIFY(parser.isSetBacklightOff());
+}
+
+void LightpackCommandLineParserTest::testCase_parseBacklightOn()
+{
+    LightpackCommandLineParser parser;
+    QString error;
+    const QStringList arguments = QStringList() << "app.binary" << "--on";
+
+    QVERIFY(parser.parse(&error, arguments));
+    QVERIFY(parser.isSetBacklightOn());
+}
+
+void LightpackCommandLineParserTest::testCase_parseBacklightOnAndOff()
+{
+    LightpackCommandLineParser parser;
+    QString error;
+    const QStringList arguments = QStringList() << "app.binary" << "--on" << "--off";
+
+    QVERIFY(!parser.parse(&error, arguments));
+    QVERIFY(parser.isSetBacklightOn());
+    QVERIFY(parser.isSetBacklightOff());
+}
+
+void LightpackCommandLineParserTest::testCase_parseDebuglevel()
+{
+    QString error;
+    const QString levelNames[] = {
+        QString("high"), QString("mid"), QString("low"), QString("zero")
+    };
+    const Debug::DebugLevels levelValues[] = {
+        Debug::HighLevel, Debug::MidLevel, Debug::LowLevel, Debug::ZeroLevel
+    };
+
+    QCOMPARE(sizeof(levelNames)/sizeof(levelNames[0]), sizeof(levelValues)/sizeof(levelValues[0]));
+    for (size_t i = 0; i < sizeof(levelNames)/sizeof(levelNames[0]); ++i)
+    {
+        LightpackCommandLineParser parser;
+        QStringList arguments = QStringList() << "app.binary" << QString("--debug=") + levelNames[i];
+        QVERIFY(parser.parse(&error, arguments));
+        QVERIFY(parser.isSetDebuglevel());
+        QCOMPARE(parser.debugLevel(), levelValues[i]);
+    }
+
+    for (size_t i = 0; i < sizeof(levelNames)/sizeof(levelNames[0]); ++i)
+    {
+        LightpackCommandLineParser parser;
+        QStringList arguments = QStringList() << "app.binary" << QString("--debug-") + levelNames[i];
+        QVERIFY(parser.parse(&error, arguments));
+        QVERIFY(parser.isSetDebuglevel());
+        QCOMPARE(parser.debugLevel(), levelValues[i]);
+    }
+}

--- a/Software/tests/LightpackCommandLineParserTest.hpp
+++ b/Software/tests/LightpackCommandLineParserTest.hpp
@@ -1,0 +1,52 @@
+/*
+ * LightpackCommandLineParserTest.hpp
+ *
+ *  Created on: 08.08.2014
+ *     Project: Lightpack
+ *
+ *  Lightpack is very simple implementation of the backlight for a laptop
+ *
+ *  Copyright (c) 2014 Woodenshark LLC
+ *
+ *  Lightpack is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Lightpack is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef LIGHTPACKCOMMANDLINEPARSERTEST_H
+#define LIGHTPACKCOMMANDLINEPARSERTEST_H
+
+#include <QtTest/QtTest>
+
+class LightpackCommandLineParserTest : public QObject
+{
+    Q_OBJECT
+public:
+    explicit LightpackCommandLineParserTest(QObject *parent = 0);
+
+private slots:
+    void initTestCase();
+
+    void init();
+    void cleanup();
+
+    void testCase_parseVersion();
+    void testCase_parseHelp();
+    void testCase_parseWizard();
+    void testCase_parseBacklightOff();
+    void testCase_parseBacklightOn();
+    void testCase_parseBacklightOnAndOff();
+    void testCase_parseDebuglevel();
+};
+
+#endif // LIGHTPACKCOMMANDLINEPARSERTEST_H

--- a/Software/tests/TestsMain.cpp
+++ b/Software/tests/TestsMain.cpp
@@ -7,6 +7,7 @@
 #ifdef Q_OS_WIN
 #include "HooksTest.h"
 #endif
+#include "LightpackCommandLineParserTest.hpp"
 #include "debug.h"
 
 #include <iostream>
@@ -22,7 +23,6 @@ int main(int argc, char *argv[])
 
     QList<QObject *> tests;
     QStringList summary;
-
     tests.append(new GrabCalculationTest());
 
 #ifdef Q_OS_WIN
@@ -32,9 +32,7 @@ int main(int argc, char *argv[])
     tests.append(new LightpackMathTest());
     tests.append(new LightpackApiTest());
     tests.append(new AppVersionTest());
-
-
-
+    tests.append(new LightpackCommandLineParserTest());
 
     for(int i=0; i < tests.size(); i++) {
         if (QTest::qExec(tests[i], argc, argv)) {

--- a/Software/tests/tests.pro
+++ b/Software/tests/tests.pro
@@ -47,6 +47,7 @@ HEADERS += \
     ../src/Settings.hpp \
     ../src/Plugin.hpp \
     ../src/LightpackPluginInterface.hpp \
+    ../src/LightpackCommandLineParser.hpp \
     ../grab/include/calculations.hpp \
     ../math/include/PrismatikMath.hpp \
     SettingsWindowMockup.hpp \
@@ -54,7 +55,8 @@ HEADERS += \
     LightpackApiTest.hpp \
     lightpackmathtest.hpp \
     AppVersionTest.hpp \
-    ../src/UpdatesProcessor.hpp
+    ../src/UpdatesProcessor.hpp \
+    LightpackCommandLineParserTest.hpp
 
 SOURCES += \
     ../src/ApiServerSetColorTask.cpp \
@@ -62,13 +64,15 @@ SOURCES += \
     ../src/Settings.cpp \
     ../src/Plugin.cpp \
     ../src/LightpackPluginInterface.cpp \
+    ../src/LightpackCommandLineParser.cpp \
     LightpackApiTest.cpp \
     SettingsWindowMockup.cpp \
     GrabCalculationTest.cpp \
     lightpackmathtest.cpp \
     TestsMain.cpp \
     AppVersionTest.cpp \
-    ../src/UpdatesProcessor.cpp
+    ../src/UpdatesProcessor.cpp \
+    LightpackCommandLineParserTest.cpp
 
 win32{
     HEADERS += \


### PR DESCRIPTION
```
- Use QCommandLineParser class to parse the command line.
- Add alternate way to set debug level (--debug=level).
- Handle --help and --version command switches.
- Add unit-tests for LightpackCommandLineParser class.
```

Fix #10
