### PR TITLE
[D3D10] Fix path of injected dll

### DIFF
--- a/Software/grab/D3D10Grabber.cpp
+++ b/Software/grab/D3D10Grabber.cpp
@@ -28,6 +28,7 @@
 #ifdef D3D10_GRAB_SUPPORT
 
 #include <winsock2.h>
+#include <shlwapi.h>
 #define WINAPI_INLINE WINAPI
 
 #include <QObject>
@@ -161,7 +162,8 @@ public:
             return true;
 
         AcquirePrivileges();
-        GetCurrentDirectoryW(SIZEOF_ARRAY(m_hooksLibPath), m_hooksLibPath);
+        GetModuleFileName(NULL, m_hooksLibPath, SIZEOF_ARRAY(m_hooksLibPath));
+        PathRemoveFileSpec(m_hooksLibPath);
         wcscat(m_hooksLibPath, L"\\");
         wcscat(m_hooksLibPath, lightpackHooksDllName);
 


### PR DESCRIPTION
![procmon](https://cloud.githubusercontent.com/assets/5766601/5519021/22faa754-8940-11e4-83b4-0c72ec12c1ce.png)

The D3D10-Grabber uses GetCurrentDirectory which is set to the plugins path at some other point. Use the binary's path instead.
