### PR TITLE
add needed include for qdatastream

### DIFF
--- a/Software/src/qtsingleapplication/src/qtlocalpeer.cpp
+++ b/Software/src/qtsingleapplication/src/qtlocalpeer.cpp
@@ -40,6 +40,7 @@
 
 
 #include "qtlocalpeer.h"
+#include <qdatastream.h>
 #include <QCoreApplication>
 #include <QTime>
 


### PR DESCRIPTION
Just got my lightpack and the application failed to build due to a missing include (i think its an issue caused by a newer version of qt). This fixed the build for me, figured i'd share.

Error i was experiencing:

```
qtsingleapplication/src/qtlocalpeer.cpp: In member function ‘bool QtLocalPeer::sendMessage(const QString&, int)’:
qtsingleapplication/src/qtlocalpeer.cpp:160:19: error: variable ‘QDataStream ds’ has initializer but incomplete type
     QDataStream ds(&socket);
```
