### PR TITLE
[firmware] Add macro to switch off enclosure LED

### DIFF
--- a/Firmware/LUFAConfig.h
+++ b/Firmware/LUFAConfig.h
@@ -64,6 +64,7 @@
 //		#define USB_STREAM_TIMEOUT_MS            {Insert Value Here}
 //		#define NO_LIMITED_CONTROLLER_CONNECT
 //		#define NO_SOF_EVENTS
+//		#define ENCLOSURE_LED_OFF
 		/* USB Device Mode Driver Related Tokens: */
 //		#define USE_RAM_DESCRIPTORS
 		#define USE_FLASH_DESCRIPTORS

--- a/Firmware/Lightpack.c
+++ b/Firmware/Lightpack.c
@@ -159,6 +159,10 @@ int main(void)
 
     sei();
 
+#ifdef ENCLOSURE_LED_OFF
+    CLR(USBLED);
+#endif
+
     for (;;)
     {
         wdt_reset();


### PR DESCRIPTION
If macro ENCLOSURE_LED_OFF is defined in the LUFAConfig.h file,
the enclosure LED will be switched off after bootup. The macro is
disabled by default.
