### PR TITLE
Fixed Readme heading formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Lightpack project with Prismatik flavour
 calculate resulting colors and provide soft and gentle lighting with Lightpack device. Moreother, you can 
 handle another devices with Prismatik such as Adalight, Ardulight or even Alienware LightFX system.
 
-#####Main features:
+##### Main features:
 * Fully open-source under GPLv3 (hardware, software, firmware)
 * Cross-platform GUI (Qt)
 * USB HID (no need to install any drivers)
 * The device is simple to build (just Do-It-Yourself) 
 
-#####Useful URLs:
+##### Useful URLs:
 * [Project mothership] (https://github.com/woodenshark/Lightpack/)
 * [Original project mothership] (https://code.google.com/p/lightpack/)
 * [Binary downloads] (https://github.com/woodenshark/Lightpack/releases)
@@ -32,19 +32,19 @@ handle another devices with Prismatik such as Adalight, Ardulight or even Alienw
 
 ---
 
-###Prismatik build instructions for Windows
-####Prerequisites:
+### Prismatik build instructions for Windows
+#### Prerequisites:
 * [Qt SDK](http://qt-project.org/downloads)
 * [Microsoft DirectX SDK](http://www.microsoft.com/en-us/download/details.aspx?id=6812)
 * POSIX shell utilities [MSYS for example](http://www.mingw.org/wiki/MSYS). Make sure `PATH` environment variable is set for the utilities (Run &rarr; sysdm.cpl &rarr; Advanced &rarr; Environment Variable &rarr; Edit `PATH` system variable (`C:\MinGW\msys\1.0\bin;` for example), path should points directly on the utilities so utilities are available without any subdirectories)
 
-####Build process:
+#### Build process:
 1. build **Prismatik** project
 
 ---
 
-###Build instructions for Linux
-####Prerequisites:
+### Build instructions for Linux
+#### Prerequisites:
 You will need the following packages, usually all of them are in distro's repository:
 * qt5-default
 * libqt5serialport5-dev
@@ -55,7 +55,7 @@ You will need the following packages, usually all of them are in distro's reposi
 * libudev-dev
 * if you are using Ubuntu: libappindicator-dev
 
-####Build process:
+#### Build process:
 1. go to `<repo>/Software`
 2. run ```qmake -r && make```
 3. Add a rule for **UDEV**. See comments from `<repo>/Software/dist_linux/deb/etc/udev/rules.d/93-lightpack.rules` for how to do it.
@@ -63,8 +63,8 @@ You will need the following packages, usually all of them are in distro's reposi
 
 ---
 
-###Build instructions for OS X
-####Prerequisites:
+### Build instructions for OS X
+#### Prerequisites:
 * Qt SDK (5.0+)
 * MacOSX 10.9.sdk
 
@@ -74,7 +74,7 @@ You will need the following packages, usually all of them are in distro's reposi
 * QtNetwork.framework
 * QtOpenGL.framework
 
-####Build process:
+#### Build process:
 1. Download and unpack 5.0+ **Qt SDK** from www.qt-project.org
 4. Build **Prismatik** project
 
@@ -82,7 +82,7 @@ to run Prismatik please make sure PythonQt libs are available for load at runtim
 
 ---
 
-###Firmware build instructions
+### Firmware build instructions
 1. Install [AVR GCC Toolchain] (http://avr-eclipse.sourceforge.net/wiki/index.php/The_AVR_GCC_Toolchain)
 2. Install **dfu-programmer** for firmware upload with `$ sudo apt-get install dfu-programmer`
 3. Compile Prismatik using command line:


### PR DESCRIPTION
Most headings were missing a space before the text, which was causing them to not be formatted as headings.